### PR TITLE
Added MUI alerts to replace browser alerts ⚠️

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^5.10.7",
         "@mui/styles": "^5.10.7",
         "firebase": "^9.9.3",
+        "notistack": "^2.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -2698,6 +2699,34 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
     },
+    "node_modules/notistack": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.5.tgz",
+      "integrity": "sha512-Ig2T1Muqkc1PaSQcEDrK7diKv6cBxw02Iq6uv074ySfgq524TV5lK41diAb6OSsaiWfp3aRt+T3+0MF8m2EcJQ==",
+      "dependencies": {
+        "clsx": "^1.1.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/notistack"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^5.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5255,6 +5284,15 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+    },
+    "notistack": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.5.tgz",
+      "integrity": "sha512-Ig2T1Muqkc1PaSQcEDrK7diKv6cBxw02Iq6uv074ySfgq524TV5lK41diAb6OSsaiWfp3aRt+T3+0MF8m2EcJQ==",
+      "requires": {
+        "clsx": "^1.1.0",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "object-assign": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@mui/material": "^5.10.7",
     "@mui/styles": "^5.10.7",
     "firebase": "^9.9.3",
+    "notistack": "^2.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ import { makeStyles } from "@mui/styles";
 import ImgUpload from "./components/ImgUpload";
 import Loader from "./components/Loader";
 import AnimatedButton from "./components/AnimatedButton";
-import SnackBar from "./components/SnackBar"
+import { useSnackbar } from "notistack";
 
 function getModalStyle() {
   const top = 50;
@@ -60,21 +60,13 @@ function App() {
     [loggingIn, signingUp, loadingPosts]
   );
   const [image, setImage] = useState(null);
+  const { enqueueSnackbar } = useSnackbar()
 
   const handleChange = (e) => {
     if (e.target.files[0]) {
       setImage(e.target.files[0]);
     }
   };
-  	const [openSnackbar, setOpenSnackbar] = useState(false)
-	const [alertSeverity, setAlertSeverity] = useState("success")
-	const [snackBarMessage, setSnackBarMessage] = useState("")
-	const openSnackBar = (severity, message) => {
-		setAlertSeverity(severity)
-		setSnackBarMessage(message)
-		setOpenSnackbar(true)
-	}
-	const snackBarprops = { open: openSnackbar, setOpen: setOpenSnackbar, alertSeverity, snackBarMessage }
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged((authUser) => {
@@ -153,7 +145,9 @@ useEffect(()=>{
           (error) => {
             // error function ...
             console.log(error);
-            openSnackBar("error", error.message);
+            enqueueSnackbar(error.message, {
+              variant: "error"
+            })
           },
           () => {
             // complete function ...
@@ -166,7 +160,9 @@ useEffect(()=>{
                   displayName: username,
                   photoURL: url,
                 });
-                openSnackBar("success", "Signup Successful!");
+                enqueueSnackbar("Signup Successful!", {
+                  variant: "success"
+                })
                 setOpenSignUp(false);
               });
           }
@@ -175,7 +171,9 @@ useEffect(()=>{
       // .then(() => {
 
       // })
-      .catch((error) => openSnackBar("error", error.message))
+      .catch((error) => enqueueSnackbar(error.message, {
+        variant: "error"
+      }))
       .finally(() => {
         setSigningUp(false);
       });
@@ -187,10 +185,14 @@ useEffect(()=>{
     auth
       .signInWithEmailAndPassword(email, password)
       .then(() => {
-        openSnackBar("success", "Login successful!");
+        enqueueSnackbar("Login successful!", {
+          variant: "success"
+        })
         setOpenSignIn(false);
       })
-      .catch((error) => openSnackBar("error", error.message))
+      .catch((error) => enqueueSnackbar(error.message, {
+        variant: "error"
+      }))
       .finally(() => {
         setLoggingIn(false);
       });
@@ -199,7 +201,9 @@ useEffect(()=>{
   const signOut = () => {
     if (confirm("Are you sure you want to logout?")) {
       auth.signOut().finally();
-      openSnackBar("info", "Logged out Successfully !")
+      enqueueSnackbar("Logged out Successfully !", {
+        variant: "info"
+      })
     }
   };
 
@@ -248,14 +252,12 @@ useEffect(()=>{
           </div>
         )}
       </div>
-      <SnackBar {...snackBarprops} />
       <Dialog open={openNewUpload} onClose={() => setOpenNewUpload(false)}>
         <DialogTitle>New Upload</DialogTitle>
         <DialogContent>
           {!loadingPosts &&
             (user ? (
               <ImgUpload
-                snackBar={openSnackBar}
                 user={user}
                 onUploadComplete={() => setOpenNewUpload(false)}
               />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import { makeStyles } from "@mui/styles";
 import ImgUpload from "./components/ImgUpload";
 import Loader from "./components/Loader";
 import AnimatedButton from "./components/AnimatedButton";
+import SnackBar from "./components/SnackBar"
 
 function getModalStyle() {
   const top = 50;
@@ -65,6 +66,15 @@ function App() {
       setImage(e.target.files[0]);
     }
   };
+  	const [openSnackbar, setOpenSnackbar] = useState(false)
+	const [alertSeverity, setAlertSeverity] = useState("success")
+	const [snackBarMessage, setSnackBarMessage] = useState("")
+	const openSnackBar = (severity, message) => {
+		setAlertSeverity(severity)
+		setSnackBarMessage(message)
+		setOpenSnackbar(true)
+	}
+	const snackBarprops = { open: openSnackbar, setOpen: setOpenSnackbar, alertSeverity, snackBarMessage }
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged((authUser) => {
@@ -143,7 +153,7 @@ useEffect(()=>{
           (error) => {
             // error function ...
             console.log(error);
-            alert(error.message);
+            openSnackBar("error", error.message);
           },
           () => {
             // complete function ...
@@ -156,7 +166,7 @@ useEffect(()=>{
                   displayName: username,
                   photoURL: url,
                 });
-                alert("Signup Successful!");
+                openSnackBar("success", "Signup Successful!");
                 setOpenSignUp(false);
               });
           }
@@ -165,7 +175,7 @@ useEffect(()=>{
       // .then(() => {
 
       // })
-      .catch((error) => alert(error.message))
+      .catch((error) => openSnackBar("error", error.message))
       .finally(() => {
         setSigningUp(false);
       });
@@ -177,10 +187,10 @@ useEffect(()=>{
     auth
       .signInWithEmailAndPassword(email, password)
       .then(() => {
-        alert("Login successful!");
+        openSnackBar("success", "Login successful!");
         setOpenSignIn(false);
       })
-      .catch((error) => alert(error.message))
+      .catch((error) => openSnackBar("error", error.message))
       .finally(() => {
         setLoggingIn(false);
       });
@@ -189,6 +199,7 @@ useEffect(()=>{
   const signOut = () => {
     if (confirm("Are you sure you want to logout?")) {
       auth.signOut().finally();
+      openSnackBar("info", "Logged out Successfully !")
     }
   };
 
@@ -237,12 +248,14 @@ useEffect(()=>{
           </div>
         )}
       </div>
+      <SnackBar {...snackBarprops} />
       <Dialog open={openNewUpload} onClose={() => setOpenNewUpload(false)}>
         <DialogTitle>New Upload</DialogTitle>
         <DialogContent>
           {!loadingPosts &&
             (user ? (
               <ImgUpload
+                snackBar={openSnackBar}
                 user={user}
                 onUploadComplete={() => setOpenNewUpload(false)}
               />

--- a/src/components/ImgUpload.jsx
+++ b/src/components/ImgUpload.jsx
@@ -3,6 +3,7 @@ import { db, handleMultiUpload, storage } from "../lib/firebase";
 import firebase from "firebase/compat/app";
 import AnimatedButton from "./AnimatedButton";
 import { LinearProgress, TextField } from "@mui/material";
+import { useSnackbar } from "notistack";
 
 function ImgUpload(props) {
   const [image, setImage] = useState(null);
@@ -17,6 +18,8 @@ function ImgUpload(props) {
     }
   };
 
+  const { enqueueSnackbar } = useSnackbar();
+
   const savePost = (imageUrl = "") => {
     db.collection("posts")
       .add({
@@ -27,7 +30,9 @@ function ImgUpload(props) {
         avatar: props.user.photoURL,
       })
       .then(() => {
-        props.snackBar("success", "Post was uploaded successfully!");
+        enqueueSnackbar("Post was uploaded successfully!", {
+          variant: "success",
+        });
         setProgress(0);
         setCaption("");
         setImage(null);
@@ -40,7 +45,9 @@ function ImgUpload(props) {
         }
       })
       .catch((err) => {
-        props.snackBar("error", err.message)
+        enqueueSnackbar(err.message, {
+          variant: "error"
+        });
 
         if (props.onUploadError) {
           props.onUploadError(err);
@@ -80,7 +87,9 @@ function ImgUpload(props) {
       })
       .catch((err) => {
         console.log(err);
-        props.snackBar("error", err.message);
+        enqueueSnackbar(err.message, {
+          variant: "error"
+        })
         setUploadingPost(false);
 
         if (props.onUploadError) {

--- a/src/components/ImgUpload.jsx
+++ b/src/components/ImgUpload.jsx
@@ -27,7 +27,7 @@ function ImgUpload(props) {
         avatar: props.user.photoURL,
       })
       .then(() => {
-        alert("Post was uploaded successfully!");
+        props.snackBar("success", "Post was uploaded successfully!");
         setProgress(0);
         setCaption("");
         setImage(null);
@@ -40,7 +40,7 @@ function ImgUpload(props) {
         }
       })
       .catch((err) => {
-        alert(err.message);
+        props.snackBar("error", err.message)
 
         if (props.onUploadError) {
           props.onUploadError(err);
@@ -80,7 +80,7 @@ function ImgUpload(props) {
       })
       .catch((err) => {
         console.log(err);
-        alert(err.message);
+        props.snackBar("error", err.message);
         setUploadingPost(false);
 
         if (props.onUploadError) {

--- a/src/components/SnackBar.jsx
+++ b/src/components/SnackBar.jsx
@@ -1,0 +1,19 @@
+// import { forwardRef, useCallback } from "react"
+import { forwardRef } from "react"
+import { Snackbar, Alert } from "@mui/material"
+
+const MuiAlert = forwardRef((props, ref) => <Alert elevation={6} ref={ref} variant="filled" {...props} />)
+
+const SnackBar = ({ open, setOpen, alertSeverity, snackBarMessage }) => {
+	const handleClose = () => setOpen(false)
+
+	return (
+		<Snackbar anchorOrigin={{ vertical: "top", horizontal: "right" }} open={open} autoHideDuration={4500} onClose={handleClose}>
+			<MuiAlert onClose={handleClose} severity={alertSeverity} sx={{ width: "100%" }}>
+				{snackBarMessage}
+			</MuiAlert>
+		</Snackbar>
+	)
+}
+
+export default SnackBar

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,15 +1,41 @@
+import { Close } from "@mui/icons-material";
+import { IconButton } from "@mui/material";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
+import { SnackbarProvider, useSnackbar } from "notistack";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
 
-const theme = createTheme()
+const theme = createTheme();
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
-      <App />
+      <SnackbarProvider
+        maxSnack={1}
+        autoHideDuration={4500}
+        anchorOrigin={{
+          vertical: "top",
+          horizontal: "right",
+        }}
+        dense
+        action={(snackbarId) => {
+          const { closeSnackbar } = useSnackbar();
+          return (
+            <IconButton
+              size="small"
+              aria-label="close"
+              color="inherit"
+              onClick={() => closeSnackbar(snackbarId)}
+            >
+              <Close fontSize="small" />
+            </IconButton>
+          );
+        }}
+      >
+        <App />
+      </SnackbarProvider>
     </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
# Use MUI Alerts 📐
- I Pritam Kundu have worked for #51 

## Changes Made
- Used Material UI to add Snackbar Component
- Added Snackbar to repalce browser alerts
  - Log In
  - Sign Up
  - Image Upload Error
  - Sign In Error
  - Firebase Error
   
- Replaced all alerts and error messages and with Snackbar Notifications

## Screenshots:

- Logging In
![logged in](https://user-images.githubusercontent.com/75939390/193527568-2242d3f9-1fc1-4b2e-bea8-bdc587f1212e.png)

- Logging Out
![logout](https://user-images.githubusercontent.com/75939390/193527575-80ad937a-fd56-4131-8f00-83eee05ba140.png)

- Error Messages
![error](https://user-images.githubusercontent.com/75939390/193527555-52ba5546-5f77-489a-961b-fab17c810f47.png)

- Creating Post 
![193544547-8cf9be78-34b5-4fd8-8364-60414cf82ad1](https://user-images.githubusercontent.com/75939390/193558878-641859f5-67bb-4b87-8d75-9f92abe28424.png)
