### PR TITLE
fixed comment alignment

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -189,6 +189,9 @@
   flex-direction: column;
   align-items: flex-start;
   font-size: 15px;
+  text-align: left;
+  word-break: break-word;
+  
 }
 
 /* signup modal */


### PR DESCRIPTION
## fix issue  #280 
This pull request addresses the alignment and readability issues with comments in the "dummygram" project. The changes include the addition of the text-align: left; and word-break: break-word; properties to ensure proper alignment and word wrapping for comments.

By applying these CSS properties, comments will now be left-aligned, resulting in a more consistent and visually appealing layout. Additionally, the word-break property ensures that long words or URLs within comments will be correctly wrapped to prevent overflow and maintain readability.

updated comment section
![check](https://github.com/narayan954/dummygram/assets/77837621/9ad91eba-0abf-4b46-918d-e3feee10eb26)
