### PR TITLE
Issue#371 - Show no. of comments in the post

### DIFF
--- a/src/components/Post.jsx
+++ b/src/components/Post.jsx
@@ -421,7 +421,11 @@ function Post(prop) {
               <input
                 className="post__input"
                 type="text"
-                placeholder="Add a comment..."
+                placeholder={
+                  comments.length !== 0
+                    ? "Add a comment..."
+                    : "Be the first one to comment..."
+                }
                 value={comment}
                 onChange={(e) => setComment(e.target.value)}
                 style={{
@@ -504,9 +508,17 @@ function Post(prop) {
                   margin: "12px 8px",
                   fontSize: "12px",
                   fontWeight: "bold",
+                  "&.Mui-disabled": {
+                    color: "#616161",
+                  },
                 }}
+                disabled={comments.length !== 0 ? false : true}
               >
-                View All comments
+                {comments.length > 1
+                  ? `View all ${comments.length} comments`
+                  : comments.length === 1
+                  ? `View 1 comment`
+                  : "No comments yet"}
               </Button>
               <DialogBox
                 open={isCommentOpen}
@@ -536,7 +548,7 @@ function Post(prop) {
                                   <p key={userComment.id}>
                                     <strong>
                                       {userComment.content.username}
-                                    </strong>{" "}
+                                    </strong>
                                     {userComment.content.text}
                                     <span
                                       onClick={(event) =>


### PR DESCRIPTION
This PR contains the following changes:

- instead of view all comments, show something like "view all 123 comments" or "view 1 comment" in case of comments.
- in case without comment, "disable the button" and show something like "no comments yet".
- in case without comment show something like "be the first one to comment" placeholder on input fields of comment.
- Changed the font color of the disabled button to #616161 since the default font color was hard to see/read in  disabled state

Screenshots: 
![image](https://github.com/narayan954/dummygram/assets/104077094/d94836b7-880e-4058-b309-4419a0f3d0b6)
![image](https://github.com/narayan954/dummygram/assets/104077094/212ada76-2522-4aef-ba5d-ae39482ed42d)
![image](https://github.com/narayan954/dummygram/assets/104077094/723f6794-da92-4976-80a2-5e442b97d65f)

