### PR TITLE
Issue#393 - Showing cursor as pointer on hovering on close icon of upload post pop-up

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -329,11 +329,9 @@ function App() {
           }}
         >
           <AiOutlineClose
-            onClick={() => {
-              setOpenNewUpload(false);
-            }}
+            onClick={() => setOpenNewUpload(false)}
             size={25}
-            style={{ position: "absolute", right: "1rem" }}
+            style={{ position: "absolute", right: "1rem", cursor: "pointer" }}
           />
           <img
             src="https://user-images.githubusercontent.com/27727921/185767526-a002a17d-c12e-4a6a-82a4-dd1a13a5ecda.png"


### PR DESCRIPTION
### Description:
- This PR is intended for the close icon button on the upload post pop-up.
- Added cursor: pointer inline style with code linting principles.
-  Showing cursor as pointer on hovering on close icon of upload post pop-up so the user can know it's clickable

### Fixes:
- This PR fixed this ISSUE:#393
