### PR TITLE
Fix data lose that was happening due to creating post

### DIFF
--- a/src/components/ImgUpload/index.jsx
+++ b/src/components/ImgUpload/index.jsx
@@ -90,7 +90,7 @@ export default function ImgUpload(props) {
       await db
         .collection("users")
         .doc(props.user.uid)
-        .set({
+        .update({
           posts: firebase.firestore.FieldValue.arrayUnion(postId), // Use postId instead of postRef.id
         });
 


### PR DESCRIPTION
This PR fixes issue no. #649 
It was somewhat tricky to find but, very crucial to implement. Everything was working fine with the user collection but, whenever the user create a new post his/her data in the collection got replaced with an array that contain just a ref for a single post.
Actually, there was a mistake in updating the doc. Instead of updating doc, it was getting replaced by the set function.