### PR TITLE
Bug Fix: Fix "Cannot read properties of null (reading 'photoURL')" error

### DIFF
--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -63,7 +63,7 @@ function SideBar() {
             }
           >
             <div className="sidebar_align">
-              {user.photoURL ? (
+              {user && user.photoURL ? (
                 <img
                   src={user.photoURL}
                   alt="profile picture"


### PR DESCRIPTION
## Description
This pull request fixes a bug that causes a "Cannot read properties of null (reading 'photoURL')" error in the code. The error occurs when the user object is null or undefined, and the code tries to access the photoURL property.

## Changes Made
Added a conditional check to verify if the user object exists before accessing the photoURL property.