### PR TITLE
bug fix for chat css alignment #895

### DIFF
--- a/src/components/CommunityChat/index.css
+++ b/src/components/CommunityChat/index.css
@@ -87,9 +87,8 @@
 
 .chat-msg-text {
   color: var(--text-secondary);
-  border-radius: 20px;
-  padding: 8px;
-  padding-right: 20px;
+  border-radius: 6px;
+  padding: 4px 8px;
   width: fit-content;
   max-width: 70%;
   box-shadow: 1px 1px 5px #59afc7;


### PR DESCRIPTION
css alignment issue for chat section bug number #895 

before :- 
<img width="752" alt="image" src="https://github.com/narayan954/dummygram/assets/68702055/28f934fa-5a17-491f-8d3b-ca223a58fd6a">

After :- 
<img width="711" alt="image" src="https://github.com/narayan954/dummygram/assets/68702055/a4325d78-f664-4bf6-9553-ce2d18c82bde">
