### PR TITLE
Fix event listener leaking

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -177,7 +177,7 @@ function App() {
       });
 
     return () => {
-      window.removeEventListener("scroll", scrollEventListener);
+      window.removeEventListener("scroll", handleMouseScroll);
       unsubscribe();
     };
   }, []);


### PR DESCRIPTION
This PR closes #1142 
Fixed the memory leaking. The event listener was not remove correctly from the useEffect as they have give name of the constant instead of the function and I think window.addEventListenere doesn't return anything. So, the constant become undefined.