### PR TITLE
fix: Added Margin Property to resolved Gap between Buttons

### DIFF
--- a/src/components/EditProfile/index.jsx
+++ b/src/components/EditProfile/index.jsx
@@ -5,8 +5,8 @@ import { useRef, useState } from "react";
 
 import BackIcon from "@mui/icons-material/ArrowBackIosNew";
 import { ClickAwayListener } from "@mui/material";
-import deleteImg from "../../js/deleteImg";
 import EditIcon from "@mui/icons-material/Edit";
+import deleteImg from "../../js/deleteImg";
 import { useNavigate } from "react-router-dom";
 import { useSnackbar } from "notistack";
 

--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -177,6 +177,7 @@ function SideBar({ anonymous }) {
                 variant="contained"
                 color="primary"
                 className="button-style"
+                style={{ marginRight: '20px' }} // Add right margin to create a gap
               >
                 Logout
               </AnimatedButton>


### PR DESCRIPTION
### GSSOC'23 Contributor
### Fixes Issue No #1137 

### Proposed Changes
- **Added Margin Right Property to Logout Button to Solved Gap Issues Between Logout and Cancel Buttons on Logout Dialogue Box.**
- **I wrote Comment that Code Line.**