### PR TITLE
fix: semicolon added on every comment (#1266)

### DIFF
--- a/src/components/ReadMore/index.jsx
+++ b/src/components/ReadMore/index.jsx
@@ -19,7 +19,7 @@ const ReadMore = ({ children, postId, picCap = false, readMore = true }) => {
 
   return (
     <>
-      <Caption caption={captionText} />;
+      <Caption caption={captionText} />
       {text.length >= 40 && (
         <span
           onClick={() => {


### PR DESCRIPTION
Removed semi colon at comments in the Comment Dialog box